### PR TITLE
Remove glam dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["steam-audio", "steam-audio-sys"]
 resolver = "2"
 
 [patch.crates-io]
-#steam-audio-sys = { path = "../steam-audiosys" }
+steam-audio-sys = { path = "./steam-audio-sys" }

--- a/steam-audio-sys/Cargo.toml
+++ b/steam-audio-sys/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 links = "phonon"
 
 [dependencies]
-glam = "0.20.2"
 lewton = "0.10.2"
 
 [build-dependencies]

--- a/steam-audio-sys/src/lib.rs
+++ b/steam-audio-sys/src/lib.rs
@@ -34,22 +34,22 @@ pub mod ffi {
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
 }
 
-impl From<glam::Vec3> for ffi::IPLVector3 {
-    fn from(vec: glam::Vec3) -> Self {
+impl From<[f32; 3]> for ffi::IPLVector3 {
+    fn from(vec: [f32; 3]) -> Self {
         ffi::IPLVector3 {
-            x: vec.x,
-            y: vec.y,
-            z: vec.z,
+            x: vec[0],
+            y: vec[1],
+            z: vec[2],
         }
     }
 }
 
-impl From<&glam::Vec3> for ffi::IPLVector3 {
-    fn from(vec: &glam::Vec3) -> Self {
+impl From<&[f32; 3]> for ffi::IPLVector3 {
+    fn from(vec: &[f32; 3]) -> Self {
         ffi::IPLVector3 {
-            x: vec.x,
-            y: vec.y,
-            z: vec.z,
+            x: vec[0],
+            y: vec[1],
+            z: vec[2],
         }
     }
 }

--- a/steam-audio/Cargo.toml
+++ b/steam-audio/Cargo.toml
@@ -13,8 +13,7 @@ license-file = "LICENSE.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-steam-audio-sys = "0.3.0"
-glam = "0.20.2"
+steam-audio-sys = { path = "../steam-audio-sys" }
 lewton = "0.10.2"
 bitflags = "1.3.2"
 rodio = "0.15.0"

--- a/steam-audio/examples/simulation.rs
+++ b/steam-audio/examples/simulation.rs
@@ -1,4 +1,3 @@
-use glam::Vec3;
 use steam_audio::{
     prelude::*,
     simulation::{simulation::SimulationSharedInputs, source::OcclusionType},
@@ -46,10 +45,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mesh_settings = StaticMeshSettings {
         vertices: vec![
-            Vec3::new(-5.0, 5.0, 0.25),
-            Vec3::new(-5.0, -5.0, 0.25),
-            Vec3::new(5.0, -5.0, 0.25),
-            Vec3::new(5.0, 5.0, 0.25),
+            [-5.0, 5.0, 0.25],
+            [-5.0, -5.0, 0.25],
+            [5.0, -5.0, 0.25],
+            [5.0, 5.0, 0.25],
         ],
         triangles: vec![[0, 1, 2], [0, 2, 3]],
         materials: vec![steam_audio::materials::GENERIC],
@@ -67,7 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let source_settings = &SourceSettings::default();
     let source = Source::new(&simulator, &source_settings)?;
 
-    let listener = Vec3::new(0.0, 0.0, 0.0);
+    let listener = [0.0; 3];
 
     simulator.set_shared_inputs(
         SimulationFlags::all(),

--- a/steam-audio/examples/wrapper.rs
+++ b/steam-audio/examples/wrapper.rs
@@ -1,6 +1,5 @@
 extern crate lewton;
 
-use glam::Vec3;
 //use steam_audio::effect::ambisonics::decode::AmbisonicsDecodeSettings;
 use steam_audio::prelude::*;
 
@@ -39,7 +38,7 @@ fn binaural_effect(
 
         let mut params = BinauralParams::default();
         params.interpolation = HRTFInterpolation::Bilinear;
-        params.direction = Vec3::new(time.cos(), 0.0, time.sin());
+        params.direction = [time.cos(), 0.0, time.sin()];
 
         binaural_effect.apply_to_buffer(&params, &mut input_buffer, &mut output_buffer)?;
 

--- a/steam-audio/src/effect/binaural.rs
+++ b/steam-audio/src/effect/binaural.rs
@@ -3,7 +3,7 @@ use steam_audio_sys::ffi;
 use crate::prelude::*;
 
 pub struct BinauralParams {
-    pub direction: glam::Vec3,
+    pub direction: [f32; 3],
     pub interpolation: HRTFInterpolation,
     pub spatial_blend: f32,
 }
@@ -11,7 +11,7 @@ pub struct BinauralParams {
 impl Default for BinauralParams {
     fn default() -> Self {
         Self {
-            direction: glam::Vec3::ZERO,
+            direction: [0.0; 3],
             interpolation: HRTFInterpolation::NearestNeighbor,
             spatial_blend: 1.0,
         }

--- a/steam-audio/src/orientation.rs
+++ b/steam-audio/src/orientation.rs
@@ -1,22 +1,20 @@
 use steam_audio_sys::ffi;
 
-use glam::Vec3;
-
 #[derive(Debug, Clone)]
 pub struct Orientation {
-    pub right: Vec3,
-    pub up: Vec3,
-    pub ahead: Vec3,
-    pub origin: Vec3,
+    pub right: [f32; 3],
+    pub up: [f32; 3],
+    pub ahead: [f32; 3],
+    pub origin: [f32; 3],
 }
 
 impl Default for Orientation {
     fn default() -> Self {
         Self {
-            right: Vec3::X,
-            up: Vec3::Y,
-            ahead: -Vec3::Z,
-            origin: Vec3::ZERO,
+            right: [1.0, 0.0, 0.0],
+            up: [0.0, 1.0, 0.0],
+            ahead: [0.0, 0.0, -1.0],
+            origin: [0.0, 0.0, 0.0],
         }
     }
 }

--- a/steam-audio/src/simulation/source.rs
+++ b/steam-audio/src/simulation/source.rs
@@ -297,7 +297,7 @@ impl Into<ffi::IPLSimulationInputs> for &SimulationInputs {
                 type_: ffi::IPLBakedDataType::IPL_BAKEDDATATYPE_PATHING,
                 variation: ffi::IPLBakedDataVariation::IPL_BAKEDDATAVARIATION_DYNAMIC,
                 endpointInfluence: ffi::IPLSphere {
-                    center: glam::Vec3::ZERO.into(),
+                    center: [0.0; 3].into(),
                     radius: 0.0,
                 },
             },

--- a/steam-audio/src/simulation/static_mesh.rs
+++ b/steam-audio/src/simulation/static_mesh.rs
@@ -1,11 +1,10 @@
-use glam::Vec3;
 use steam_audio_sys::ffi;
 
 use crate::prelude::*;
 
 #[derive(Debug, Clone)]
 pub struct StaticMeshSettings {
-    pub vertices: Vec<Vec3>,
+    pub vertices: Vec<[f32; 3]>,
     pub triangles: Vec<[i32; 3]>,
     pub materials: Vec<Material>,
     pub material_indices: Vec<i32>,


### PR DESCRIPTION
As a wrapper it is not expected that we will use the functionality that glam provides.
Additionally, this makes integration easier for dependents.